### PR TITLE
#1 | Fix issues with emojis and hyphens

### DIFF
--- a/envcraft.sh
+++ b/envcraft.sh
@@ -111,7 +111,7 @@ generateEnv(){
   fi
   source "${OUTPUT_FILE}"
 
-  if [ -z "${!variable}" ]; then
+  if [[ $(declare -p variable 2>/dev/null) =~ "declare -- variable=" ]]; then
     echo -n "${prompt:-Please enter a value for \"${variable}\"} (default: ${default:-<empty>}): "
     IFS= read -r VALUE < /dev/tty
 


### PR DESCRIPTION
I saw that the error message with the "special" characters was coming from this specific check in newer bash so I used another syntax which seems to fix the problem.